### PR TITLE
Fix typo in my email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<center> 
+<center>
 
-# The Coding Boot Camp Pipeline Network 
+# The Coding Boot Camp Pipeline Network
 </center>
 
 <p align="center">
@@ -55,7 +55,7 @@ Post an [issue](https://github.com/ProjectCodex/TCBC-PipelineNetwork/issues) to 
 * "Jon Disla" <jon@projectcodex.biz> - Full Stack Developer
 * "Jeff Nabors" <jeffnaborsdev@gmail.com> - Full Stack Developer
 * "James Calderon" <j.e.calderon@gmail.com> - Software Developer
-* "Javier Carrion" <javiercarrionjr@outlook.co> - QA Analyst
+* "Javier Carrion" <javiercarrionjr@outlook.com> - QA Analyst
 
 ## License
 


### PR DESCRIPTION
It guess at the stroke of midnight I realize it was my bday and somehow that "m" at the end of my email ran away. 

Here is my my fix for my email typo in the README.md document. 